### PR TITLE
fix: Resolve build.gradle.kts configuration errors

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,6 +23,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            isTestCoverageEnabled = true
+        }
         release {
             isMinifyEnabled = false
             proguardFiles(
@@ -32,22 +35,22 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true
         buildConfig = true
     }
     
-    // Test coverage configuration
-    testCoverageEnabled = true
-    
     testOptions {
-        unitTests.isIncludeAndroidResources = true
+        unitTests {
+            isIncludeAndroidResources = true
+            isReturnDefaultValues = true
+        }
         animationsDisabled = true
     }
     


### PR DESCRIPTION
## Description
This PR fixes the build error preventing the project from compiling after Phase 1 implementation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (specify)

## Problem
The build was failing with:
```
e: file:///home/okhan80/StudioProjects/BoomWisdomDivision/app/build.gradle.kts:47:5: 
Unresolved reference: testCoverageEnabled
```

## Root Cause
`testCoverageEnabled` was placed at the wrong level in the build configuration. It should be inside a buildType block, not at the module level.

## Solution
1. **Moved test coverage configuration**:
   - Removed invalid `testCoverageEnabled = true` from module level
   - Added `isTestCoverageEnabled = true` inside debug buildType

2. **Fixed test options syntax**:
   - Properly configured `unitTests` block
   - Added `isReturnDefaultValues = true` for better test support

3. **Updated Java version consistency**:
   - Changed remaining Java 11 references to Java 17
   - Ensures consistency with CI/CD configuration

## Changes Made
```kotlin
// Before (incorrect):
testCoverageEnabled = true

// After (correct):
buildTypes {
    debug {
        isTestCoverageEnabled = true
    }
}
```

## Testing
- [x] Project now builds successfully
- [x] Gradle sync completes without errors
- [x] Test coverage still enabled for debug builds

## Impact
- ✅ Project can now be built and run
- ✅ Test coverage reporting remains functional
- ✅ No breaking changes

## Checklist
- [x] Code follows Kotlin/Android conventions
- [x] Self-review completed
- [x] Fixes critical build issue
- [x] No additional dependencies added